### PR TITLE
Reorganizando links existentes, incluindo novos desafios

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,15 @@ Open source's challenges of fullstack jobs to test your skills.
 Only fullstack challenges. Only open source.
 
 ### EN :us:
-- [Tinder](https://github.com/Tinder/fullstack_coding_challenge)
-- [Unbabel](https://github.com/Unbabel/fullstack-coding-challenge)
-- [Fusemachines](https://github.com/Fusemachines/FullStackChallenge_001)
 - [Finimize](https://github.com/finimize/fullstack-dev-challenge)
 - [Itexico](https://github.com/itexico/interview-codingchallenge-fsjs)
+- [RivetAI](https://github.com/endcue/fullstack-challenge)
+- [Techstars](https://github.com/techstars/full-stack-challenge)
+- [Unbabel](https://github.com/Unbabel/fullstack-coding-challenge)
 
 ### PT :brazil:
 - [Cubo](https://github.com/cubonetwork/fullstack-challenge)
 - [Entria](https://github.com/entria/jobs/blob/master/fullstack/challenge.md)
+- [Hospede](https://github.com/hospede/fullstack-challenge)
 - [RoutEasy](https://github.com/RoutEasy/challenge-fullstack)
+- [Softplan](https://github.com/g-cpa-squad-produto/softplan-desafio-fullstack)


### PR DESCRIPTION
Os links para os desafios do Tinder e Fusemachines foram removidos, pois estão quebrados